### PR TITLE
Conditionally Set Grpc Client Type

### DIFF
--- a/lib/src/brambl/data_api/bifrost_query_algebra.dart
+++ b/lib/src/brambl/data_api/bifrost_query_algebra.dart
@@ -1,5 +1,5 @@
 import 'package:fixnum/fixnum.dart';
-import 'package:grpc/grpc.dart';
+import '../utils/grpc_native_channel_type.dart' if (dart.library.html) '../../utils/grpc_web_channel_type.dart';
 import 'package:topl_common/proto/brambl/models/identifier.pb.dart';
 import 'package:topl_common/proto/brambl/models/transaction/io_transaction.pb.dart';
 import 'package:topl_common/proto/consensus/models/block_id.pb.dart';
@@ -23,7 +23,7 @@ sealed class BifrostQueryAlgbraDefinition {
 /// Defines a Bifrost Query API for interacting with a Bifrost node.
 class BifrostQueryAlgebra implements BifrostQueryAlgbraDefinition {
   /// The gRPC channel to the node.
-  final ClientChannel channel;
+  final Channel channel;
 
   /// The client stub for the node rpc service
   late NodeRpcClient client;

--- a/lib/src/brambl/data_api/genus_query_algebra.dart
+++ b/lib/src/brambl/data_api/genus_query_algebra.dart
@@ -1,4 +1,4 @@
-import 'package:grpc/grpc.dart';
+import '../utils/grpc_native_channel_type.dart' if (dart.library.html) '../../utils/grpc_web_channel_type.dart';
 import 'package:topl_common/proto/brambl/models/address.pb.dart';
 import 'package:topl_common/proto/genus/genus_models.pb.dart';
 import 'package:topl_common/proto/genus/genus_rpc.pbgrpc.dart';
@@ -6,7 +6,7 @@ import 'package:topl_common/proto/genus/genus_rpc.pbgrpc.dart';
 /// Defines a Genus Query API for interacting with a Genus node.
 class GenusQueryAlgebra {
   /// The gRPC channel to the node.
-  final ClientChannel channel;
+  final Channel channel;
 
   /// The client stub for the transaction rpc service
   late TransactionServiceClient client;

--- a/lib/src/brambl/utils/grpc_native_channel_type.dart
+++ b/lib/src/brambl/utils/grpc_native_channel_type.dart
@@ -1,0 +1,3 @@
+import 'package:grpc/grpc.dart';
+
+typedef Channel = ClientChannel;

--- a/lib/src/brambl/utils/grpc_web_channel_type.dart
+++ b/lib/src/brambl/utils/grpc_web_channel_type.dart
@@ -1,0 +1,3 @@
+import 'package:grpc/grpc_web.dart';
+
+typedef Channel = GrpcWebClientChannel;


### PR DESCRIPTION
## Description

- Conditionally set the GRPC Client Channel Type to allow grpc requests for native and web applications

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

-   [ ] Test A
-   [ ] Test B

## Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have added screenshots