### PR TITLE
Tsdk 651 template builder error

### DIFF
--- a/lib/src/brambl/builders/locks/lock_template.dart
+++ b/lib/src/brambl/builders/locks/lock_template.dart
@@ -49,7 +49,7 @@ class PredicateTemplate implements LockTemplate {
     final result =
         ThresholdTemplate(innerTemplates, threshold).build(entityVks);
     return result.flatMap((ip) {
-      if (ip is Proposition_Threshold) {
+      if (ip.hasThreshold()) {
         final innerPropositions = ip.threshold.challenges;
         return Either.right(Lock(
           predicate: Lock_Predicate(


### PR DESCRIPTION
Implementation fixes reported issue where `locktemplate.build` return instance of `Either{_left: BuilderError{message: Unexpected inner proposition type: Proposition, type: null, exception: null}, _right: null}`

This was because of a If check that was checking the protobuf type member in a wrong way.

Solves TSDK-651