### PR TITLE
Export SCrypt

### DIFF
--- a/lib/src/crypto/crypto.dart
+++ b/lib/src/crypto/crypto.dart
@@ -1,6 +1,9 @@
 /// exports all Crypto libraries
 library brambldart.crypto;
 
+/// Encryption.KDF
+export 'encryption/kdf/scrypt.dart';
+
 /// Encryption
 export 'encryption/mac.dart';
 export 'encryption/vault_store.dart';


### PR DESCRIPTION
## Description
- In "debug" mode, some users may wish to override the scrypt parameters, but scrypt is not currently exported

Fixes #BN-1539

## Type of change
- Export scrypt file in crypto library

## How Has This Been Tested?
- Tested locally with Bridge UI