### PR TITLE
gRPC Channel Helper Replacements

### DIFF
--- a/lib/src/brambl/brambl.dart
+++ b/lib/src/brambl/brambl.dart
@@ -25,7 +25,7 @@ export 'syntax/syntax.dart';
 
 /// --- Utils ---
 export 'utils/encoding.dart';
-export 'utils/grpc/grpc.dart';
+export 'utils/grpc/channel_factory.dart';
 export 'utils/proto_converters.dart';
 export 'wallet/credentialler.dart';
 

--- a/lib/src/brambl/data_api/bifrost_query_algebra.dart
+++ b/lib/src/brambl/data_api/bifrost_query_algebra.dart
@@ -1,5 +1,5 @@
 import 'package:fixnum/fixnum.dart';
-import 'package:grpc/grpc.dart';
+import 'package:grpc/grpc_connection_interface.dart';
 import 'package:topl_common/proto/brambl/models/identifier.pb.dart';
 import 'package:topl_common/proto/brambl/models/transaction/io_transaction.pb.dart';
 import 'package:topl_common/proto/consensus/models/block_id.pb.dart';
@@ -26,7 +26,7 @@ class BifrostQueryAlgebra implements BifrostQueryAlgbraDefinition {
   BifrostQueryAlgebra(this.channel) : client = NodeRpcClient(channel);
 
   /// The gRPC channel to the node.
-  final ClientChannel channel;
+  final ClientChannelBase channel;
 
   /// The client stub for the node rpc service
   final NodeRpcClient client;

--- a/lib/src/brambl/data_api/bifrost_query_algebra.dart
+++ b/lib/src/brambl/data_api/bifrost_query_algebra.dart
@@ -1,17 +1,17 @@
 import 'package:fixnum/fixnum.dart';
+import 'package:grpc/grpc.dart';
 import 'package:topl_common/proto/brambl/models/identifier.pb.dart';
 import 'package:topl_common/proto/brambl/models/transaction/io_transaction.pb.dart';
 import 'package:topl_common/proto/consensus/models/block_id.pb.dart';
 import 'package:topl_common/proto/node/models/block.pb.dart';
 import 'package:topl_common/proto/node/services/bifrost_rpc.pbgrpc.dart';
 
-import '../../../brambldart.dart';
-
 /// Defines a Bifrost Query API for interacting with a Bifrost node.
 sealed class BifrostQueryAlgbraDefinition {
   /// Fetches a block by its blockheight [height].
   /// Returns the [BlockId], [BlockBody], and contained transactions [IoTransactions] of the fetched block, if it exists.
-  Future<(BlockId, BlockBody, List<IoTransaction>)?> blockByHeight(Int64 height);
+  Future<(BlockId, BlockBody, List<IoTransaction>)?> blockByHeight(
+      Int64 height);
 
   /// Fetches a block by its [blockId.
   /// Returns a [BlockId], [BlockBody], and List of contained transactions [IoTransactions] of the fetched block, if it exists.
@@ -26,13 +26,14 @@ class BifrostQueryAlgebra implements BifrostQueryAlgbraDefinition {
   BifrostQueryAlgebra(this.channel) : client = NodeRpcClient(channel);
 
   /// The gRPC channel to the node.
-  final Channel channel;
+  final ClientChannel channel;
 
   /// The client stub for the node rpc service
   final NodeRpcClient client;
 
   @override
-  Future<(BlockId, BlockBody, List<IoTransaction>)?> blockByHeight(Int64 height) async {
+  Future<(BlockId, BlockBody, List<IoTransaction>)?> blockByHeight(
+      Int64 height) async {
     final req = FetchBlockIdAtHeightReq(height: height);
     final blockId = (await client.fetchBlockIdAtHeight(req)).blockId;
 
@@ -41,14 +42,17 @@ class BifrostQueryAlgebra implements BifrostQueryAlgbraDefinition {
   }
 
   @override
-  Future<(BlockId, BlockBody, List<IoTransaction>)?> blockById(BlockId blockId) async {
+  Future<(BlockId, BlockBody, List<IoTransaction>)?> blockById(
+      BlockId blockId) async {
     final req = FetchBlockBodyReq(blockId: blockId);
     final body = (await client.fetchBlockBody(req)).body;
 
     final txIds = body.transactionIds;
 
-    final List<Future<IoTransaction?>> futures = txIds.map((id) => fetchTransaction(id)).toList();
-    final List<IoTransaction> transactions = (await Future.wait(futures)).whereType<IoTransaction>().toList();
+    final List<Future<IoTransaction?>> futures =
+        txIds.map((id) => fetchTransaction(id)).toList();
+    final List<IoTransaction> transactions =
+        (await Future.wait(futures)).whereType<IoTransaction>().toList();
 
     return (blockId, body, transactions);
   }

--- a/lib/src/brambl/data_api/genus_query_algebra.dart
+++ b/lib/src/brambl/data_api/genus_query_algebra.dart
@@ -1,15 +1,14 @@
+import 'package:grpc/service_api.dart';
 import 'package:topl_common/proto/brambl/models/address.pb.dart';
 import 'package:topl_common/proto/genus/genus_models.pb.dart';
 import 'package:topl_common/proto/genus/genus_rpc.pbgrpc.dart';
-
-import '../utils/grpc/grpc.dart';
 
 /// Defines a Genus Query API for interacting with a Genus node.
 class GenusQueryAlgebra {
   GenusQueryAlgebra(this.channel) : client = TransactionServiceClient(channel);
 
   /// The gRPC channel to the node.
-  final Channel channel;
+  final ClientChannel channel;
 
   /// The client stub for the transaction rpc service
   final TransactionServiceClient client;
@@ -19,7 +18,9 @@ class GenusQueryAlgebra {
   /// [fromAddress] The lock address to query the unspent UTXOs by.
   /// [txoState] The state of the UTXOs to query. By default, only unspent UTXOs are returned.
   /// returns A sequence of UTXOs.
-  Future<List<Txo>> queryUtxo({required LockAddress fromAddress, TxoState txoState = TxoState.UNSPENT}) async {
+  Future<List<Txo>> queryUtxo(
+      {required LockAddress fromAddress,
+      TxoState txoState = TxoState.UNSPENT}) async {
     final response = await client.getTxosByLockAddress(
       QueryByLockAddressRequest(address: fromAddress, state: txoState),
     );

--- a/lib/src/brambl/data_api/genus_query_algebra.dart
+++ b/lib/src/brambl/data_api/genus_query_algebra.dart
@@ -1,4 +1,4 @@
-import 'package:grpc/service_api.dart';
+import 'package:grpc/grpc_connection_interface.dart';
 import 'package:topl_common/proto/brambl/models/address.pb.dart';
 import 'package:topl_common/proto/genus/genus_models.pb.dart';
 import 'package:topl_common/proto/genus/genus_rpc.pbgrpc.dart';
@@ -8,7 +8,7 @@ class GenusQueryAlgebra {
   GenusQueryAlgebra(this.channel) : client = TransactionServiceClient(channel);
 
   /// The gRPC channel to the node.
-  final ClientChannel channel;
+  final ClientChannelBase channel;
 
   /// The client stub for the transaction rpc service
   final TransactionServiceClient client;

--- a/lib/src/brambl/utils/grpc/channel_factory.dart
+++ b/lib/src/brambl/utils/grpc/channel_factory.dart
@@ -1,0 +1,2 @@
+export 'channel_factory_non_web.dart'
+    if (dart.library.html) 'channel_factory_web.dart';

--- a/lib/src/brambl/utils/grpc/channel_factory_non_web.dart
+++ b/lib/src/brambl/utils/grpc/channel_factory_non_web.dart
@@ -1,0 +1,11 @@
+import 'package:grpc/grpc.dart';
+import 'package:grpc/grpc_connection_interface.dart';
+
+ClientChannelBase makeChannel(String host, int port, bool secure) {
+  return ClientChannel(host,
+      port: port,
+      options: ChannelOptions(
+          credentials: secure
+              ? const ChannelCredentials.secure()
+              : const ChannelCredentials.insecure()));
+}

--- a/lib/src/brambl/utils/grpc/channel_factory_web.dart
+++ b/lib/src/brambl/utils/grpc/channel_factory_web.dart
@@ -1,0 +1,8 @@
+import 'package:grpc/grpc_connection_interface.dart';
+import 'package:grpc/grpc_web.dart';
+
+ClientChannelBase makeChannel(String host, int port, bool secure) {
+  final prefix = secure ? "https://" : "http://";
+  final uri = "$prefix$host:$port";
+  return GrpcWebClientChannel.xhr(Uri.parse(uri));
+}

--- a/lib/src/brambl/utils/grpc/grpc.dart
+++ b/lib/src/brambl/utils/grpc/grpc.dart
@@ -1,3 +1,0 @@
-export 'grpc_native_channel_type.dart' if (dart.library.html) 'grpc_web_channel_type.dart';
-
-/// Import this file for conditional imports of the grpc library.

--- a/lib/src/brambl/utils/grpc/grpc_native_channel_type.dart
+++ b/lib/src/brambl/utils/grpc/grpc_native_channel_type.dart
@@ -1,3 +1,0 @@
-import 'package:grpc/grpc.dart';
-
-typedef Channel = ClientChannel;

--- a/lib/src/brambl/utils/grpc/grpc_web_channel_type.dart
+++ b/lib/src/brambl/utils/grpc/grpc_web_channel_type.dart
@@ -1,3 +1,0 @@
-import 'package:grpc/grpc_web.dart';
-
-typedef Channel = GrpcWebClientChannel;


### PR DESCRIPTION
## Description
- The current helpers for gRPC vs. gRPC-web are a bit cumbersome
Fixes #1539

## Type of change
- Lower type constraints of Bifrost/GenusQueryAlgebra channel parameter
- Create a helper for constructing a gRPC channel (vs. the original implementation which was a simple type alias)
## How Has This Been Tested?
- Tested in local Bridge UI